### PR TITLE
Display segments background color correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ __highlightTextColor__: UIColor - Text color for selected segment
 
 __segmentsBackgroundColor__: UIColor - Background color for unselected segments
 
-__highlightTextColor__: UIColor - Background color for selected segment
+__sliderBackgroundColor__: UIColor - Background color for selected segment
 
 ###Installation:
 ####• CocoaPods

--- a/TwicketSegmentedControl/TwicketSegmentedControl.swift
+++ b/TwicketSegmentedControl/TwicketSegmentedControl.swift
@@ -84,6 +84,7 @@ open class TwicketSegmentedControl: UIControl {
     open var sliderBackgroundColor: UIColor = Palette.sliderColor {
         didSet {
             selectedContainerView.backgroundColor = sliderBackgroundColor
+            selectedContainerView.addShadow(with: sliderBackgroundColor)
         }
     }
 

--- a/TwicketSegmentedControl/TwicketSegmentedControl.swift
+++ b/TwicketSegmentedControl/TwicketSegmentedControl.swift
@@ -77,7 +77,7 @@ open class TwicketSegmentedControl: UIControl {
 
     open var segmentsBackgroundColor: UIColor = Palette.segmentedControlBackgroundColor {
         didSet {
-            backgroundView.backgroundColor = backgroundColor
+            backgroundView.backgroundColor = segmentsBackgroundColor
         }
     }
 


### PR DESCRIPTION
Quick fix. I don't suppose it was intended to match segments background colour to background colour of segmentedControl.