### PR TITLE
Delegate callback now returns instance of TwicketSegmentedControl

### DIFF
--- a/TwicketSegmentedControl/TwicketSegmentedControl.swift
+++ b/TwicketSegmentedControl/TwicketSegmentedControl.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public protocol TwicketSegmentedControlDelegate: class {
-    func didSelect(_ segmentIndex: Int)
+    func twicketSegmentedControl(_ segmentedControl: TwicketSegmentedControl, didSelect segmentIndex: Int)
 }
 
 open class TwicketSegmentedControl: UIControl {
@@ -267,7 +267,7 @@ open class TwicketSegmentedControl: UIControl {
         }
         let index = segmentIndex(for: location)
         move(to: index)
-        delegate?.didSelect(index)
+        delegate?.twicketSegmentedControl(self, didSelect: index)
     }
 
     open func move(to index: Int) {

--- a/TwicketSegmentedControl/TwicketSegmentedControl.swift
+++ b/TwicketSegmentedControl/TwicketSegmentedControl.swift
@@ -13,10 +13,10 @@ public protocol TwicketSegmentedControlDelegate: class {
 }
 
 open class TwicketSegmentedControl: UIControl {
-    open static let height: CGFloat = Constants.height + Constants.topBottomMargin * 2
+    public static let height: CGFloat = Constants.height + Constants.topBottomMargin * 2
 
     private struct Constants {
-        static let height: CGFloat = 30
+        static var height: CGFloat = 30
         static let topBottomMargin: CGFloat = 5
         static let leadingTrailingMargin: CGFloat = 10
     }
@@ -91,6 +91,26 @@ open class TwicketSegmentedControl: UIControl {
     open var font: UIFont = UIFont.systemFont(ofSize: 15, weight: UIFontWeightMedium) {
         didSet {
             updateLabelsFont(with: font)
+        }
+    }
+    
+    open var height: CGFloat {
+        get {
+            return Constants.height
+        }
+        
+        set {
+            Constants.height = newValue
+        }
+    }
+    
+    open var cornerRadius: CGFloat {
+        get {
+            return sliderView.cornerRadius
+        }
+        
+        set {
+            sliderView.cornerRadius = newValue
         }
     }
 

--- a/TwicketSegmentedControl/TwicketSegmentedControl.swift
+++ b/TwicketSegmentedControl/TwicketSegmentedControl.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public protocol TwicketSegmentedControlDelegate: class {
-    func twicketSegmentedControl(_ segmentedControl: TwicketSegmentedControl, didSelect segmentIndex: Int)
+    func didSelect(_ segmentIndex: Int, on segmentedControl: TwicketSegmentedControl)
 }
 
 open class TwicketSegmentedControl: UIControl {
@@ -287,7 +287,7 @@ open class TwicketSegmentedControl: UIControl {
         }
         let index = segmentIndex(for: location)
         move(to: index)
-        delegate?.twicketSegmentedControl(self, didSelect: index)
+        delegate?.didSelect(index, on: self)
     }
 
     open func move(to index: Int) {

--- a/TwicketSegmentedControlDemo/TwicketSegmentedControlDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/TwicketSegmentedControlDemo/TwicketSegmentedControlDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
The current delegate callback makes it impossible to have multiple TwicketSegmentedControls within one class. This commit fixed this by adding the TwicketSegmentedControl instance to the delegate callback parameters.