### PR TITLE
Add optional/default animation bool to provide non-animated index sel…

### DIFF
--- a/TwicketSegmentedControl/TwicketSegmentedControl.swift
+++ b/TwicketSegmentedControl/TwicketSegmentedControl.swift
@@ -270,10 +270,13 @@ open class TwicketSegmentedControl: UIControl {
         delegate?.didSelect(index)
     }
 
-    open func move(to index: Int) {
+    open func move(to index: Int, animated:Bool? = true) {
         let correctOffset = center(at: index)
-        animate(to: correctOffset)
-
+        if animated == true{
+            animate(to: correctOffset)
+        }else{
+            self.sliderView.center.x = correctOffset
+        }
         selectedSegmentIndex = index
     }
 


### PR DESCRIPTION
Hi,

Fantastic library! I recently used this segment control in a small project. I had a use case where I wanted to refresh a UIView that contained the TwicketSegmentedControl and default it to the current selection. However, because the move(to index: Int) was always animated, it became obvious the view was being refreshed. 

I thought it may be beneficial to have the ability to move the selectedSegmentIndex without animation. The new optional/defaulting animation parameter on the move function should not affect any existing calls or break any code from what it appears.

Cheers!
Matt