### PR TITLE
Fixed a compilation error on Swift 3

### DIFF
--- a/TwicketSegmentedControl/TwicketSegmentedControl.swift
+++ b/TwicketSegmentedControl/TwicketSegmentedControl.swift
@@ -88,7 +88,7 @@ open class TwicketSegmentedControl: UIControl {
         }
     }
 
-    open var font: UIFont = UIFont.systemFont(ofSize: 15, weight: UIFontWeightMedium) {
+    open var font: UIFont = UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.medium) {
         didSet {
             updateLabelsFont(with: font)
         }


### PR DESCRIPTION
The property UIFontWeightMedium is no longer available and has
been replaced by UIFont.Weight.medium